### PR TITLE
User feed events

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,10 +85,11 @@ class User < ActiveRecord::Base
     self.received_frequests + self.sent_frequests
   end
   
-  # Returns a users feed
+  # Returns a user's feed
   def feed
     # creator id is within user.friends' ids
-    friend_ids = self.friends.map { |f| f.id }
-    Event.where({ creator_id: friend_ids })
+    ids = self.friends.map { |f| f.id }
+    ids << self.id
+    Event.where({ creator_id: ids })
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,6 @@ class User < ActiveRecord::Base
     # creator id is within user.friends' ids
     ids = self.friends.map { |f| f.id }
     ids << self.id
-    Event.where({ creator_id: ids })
+    Event.where({ creator_id: ids }).order(start_time: :desc)
   end
 end

--- a/app/views/static_pages/_user_home.html.haml
+++ b/app/views/static_pages/_user_home.html.haml
@@ -21,7 +21,7 @@
   - @feed_items.each do |event|
     %h5
       = gravatar_for(event.creator, size: 35)
-      = event.creator.full_name 
+      = current_user?(event.creator) ? "You" : event.creator.full_name 
       created
       = link_to event.title, event_path(event)
       \- for

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,6 +65,20 @@ describe User do
     user.register(event)
     expect(user.attended_events).to include(event)
   end
-  
+  context "#feed" do
+    it "returns a friend's events" do
+      user = create(:user)
+      friend = create(:user)
+      user.friends << friend
+      event = create(:event, creator_id: friend.id)
+      expect(user.feed).to include(event)
+    end
+    
+    it "returns a users events" do
+      user = create(:user)
+      event = create(:event, creator_id: user.id)
+      expect(user.feed).to include(event)
+    end
+  end
   
 end


### PR DESCRIPTION
Add current user's own events to homepage feed and update view to include them. Order events by the most recent start date.