### PR TITLE
Signup processor

### DIFF
--- a/app/controllers/friendship_requests_controller.rb
+++ b/app/controllers/friendship_requests_controller.rb
@@ -27,7 +27,7 @@ class FriendshipRequestsController < ApplicationController
   end
   
   def index
-    @friendship_requests = current_user.pending_frequests
+    @pending_requests = current_user.pending_frequests
   end
   
   private

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,6 +3,7 @@ class RegistrationsController < Devise::RegistrationsController
   def create
     super
     UserMailer.welcome_email(@user).deliver_now if @user.errors.empty? && @user.persisted?
+    SignupProcessor.create_friendship_requests
   end
 
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,7 +3,8 @@ class RegistrationsController < Devise::RegistrationsController
   def create
     super
     UserMailer.welcome_email(@user).deliver_now if @user.errors.empty? && @user.persisted?
-    SignupProcessor.create_friendship_requests
+    processor = SignupProcessor.new(@user)
+    processor.create_friendship_requests
   end
 
 end

--- a/app/models/signup_processor.rb
+++ b/app/models/signup_processor.rb
@@ -4,4 +4,7 @@ class SignupProcessor
   def initialize(user)
     @user = user
   end
+  
+  def find_invitations_by_email
+  end
 end

--- a/app/models/signup_processor.rb
+++ b/app/models/signup_processor.rb
@@ -1,0 +1,7 @@
+class SignupProcessor
+  attr_accessor :user
+  
+  def initialize(user)
+    @user = user
+  end
+end

--- a/app/models/signup_processor.rb
+++ b/app/models/signup_processor.rb
@@ -6,5 +6,14 @@ class SignupProcessor
   end
   
   def find_invitations_by_email
+    Invitation.where(email: @user.email)
   end
+  
+  def create_friendship_requests
+    invitations = self.find_invitations_by_email
+    invitations.each do |inv|
+      FriendshipRequest.create(sender_id: inv.inviter_id, receiver_id: @user.id, status: "pending")
+    end
+  end
+  
 end

--- a/app/views/friendship_requests/index.html.haml
+++ b/app/views/friendship_requests/index.html.haml
@@ -2,16 +2,13 @@
   %h4
     No pending friend requests
     
-- else 
-  - @pending_requests.each do |friend|
+- else
+  %h4
+    Pending friend requests
+  - @pending_requests.each do |req|
     %h4 
-      Pnding friend requests
-      = link_to .full_name
-      = link_to "Approve", "#"
-      = link_To "Decline", "#"
-
-      - @user.pending_frequests.each do |req|
-        %p
-          = req.sender.full_name
-          = link_to "Confirm", friendship_request_path(req, status: "accepted"), method: :patch
-          = link_to "Delete", friendship_request_path(req, status: "declined"), method: :patch
+      = gravatar_for(req.sender)
+      = link_to req.sender.full_name, user_path(req.sender)
+    %p
+      = link_to "Accept", friendship_request_path(req, status: "accepted"), method: :patch
+      = link_to "Delete", friendship_request_path(req, status: "declined"), method: :patch

--- a/app/views/shared/_friendship_requests.html.haml
+++ b/app/views/shared/_friendship_requests.html.haml
@@ -6,7 +6,7 @@
     - @user.pending_frequests.each do |req|
       %p
         = req.sender.full_name
-        = link_to "Confirm", friendship_request_path(req, status: "accepted"), method: :patch
+        = link_to "Accept", friendship_request_path(req, status: "accepted"), method: :patch
         = link_to "Delete", friendship_request_path(req, status: "declined"), method: :patch
   
   / If it's someone else's profile page
@@ -15,8 +15,15 @@
     %p 
       Friends with
       = @user.first_name
+  - elsif req = FriendshipRequest.find_by(sender_id: @user.id, receiver_id: current_user.id, status: "pending")
+    %p
+      Pending friendship request from
+      = @user.full_name
+      = link_to "Accept", friendship_request_path(req, status: "accepted"), method: :patch
+      = link_to "Delete", friendship_request_path(req, status: "declined"), method: :patch
   - elsif FriendshipRequest.requestable?(current_user, @user)
     = link_to "Add as Connection", friendship_requests_path(receiver_id: @user.id), method: :post
   - else
-    %p (Pending friend request)
+    %p
+      Pending friendship request
   

--- a/app/views/static_pages/getting_started.html.haml
+++ b/app/views/static_pages/getting_started.html.haml
@@ -43,7 +43,7 @@
 
 %p Studygroups are completely self-organizing and self-generated.
 
-%p Your "class" will probably have a fantastic student to faculty ratio at first.
+%p Your "class" will probably have a fantastic student to faculty ratio at first. 1:1. You!
 
 %p If you are working on learning something, publish an event with a short description and others can find and join you.
 

--- a/app/views/static_pages/getting_started.html.haml
+++ b/app/views/static_pages/getting_started.html.haml
@@ -20,7 +20,7 @@
 
 %p Studygroup is designed to be simple and help you find other people to learn things with quickly.
 
-%p If you are want to start learning "X", set up a short profile description about your learning objectives and tag yourself with interests.
+%p If you want to start learning "X", set up a short profile description about your learning objectives and tag yourself with interests.
 
 %p You will be able see other people who have the same interests and coordinate to learn together.
 
@@ -57,4 +57,4 @@
 
 %h3 Why did you make Studygroup?
 
-%p I made Studygroup because I have a Sociology degree. Now I build websites.
+%p I made Studygroup because I have a Sociology degree and now I build websites!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -46,7 +46,7 @@ describe Event do
     it "returns past events" do
       past_event = create(:event, start_time: 24.hours.ago, end_time: 23.hours.ago)
       other_event = create(:event, start_time: 24.hours.ago, end_time: 23.hours.ago)
-      past_events = expect(Event.past_events).to eq [past_event, other_event]
+      expect(Event.past_events).to include past_event, other_event
     end
     
     it "doesn't return events that are still upcoming" do
@@ -60,7 +60,7 @@ describe Event do
       current_event = create(:event, start_time: Time.now + 1.hours)
       upcoming_event = create(:event)
       past_event = create(:event, start_time: 25.hours.ago, end_time: 24.hours.ago)
-      expect(Event.upcoming_events).to eq [current_event, upcoming_event]
+      expect(Event.upcoming_events).to include current_event, upcoming_event
     end
     it "doesn't return past events" do
       current_event = create(:event, start_time: Time.now)

--- a/spec/models/signup_processor_spec.rb
+++ b/spec/models/signup_processor_spec.rb
@@ -1,10 +1,26 @@
 require 'rails_helper'
 
 context "Signup_Processor" do
+  let! (:user) { FactoryGirl.create(:user)}
   
   subject { SignupProcessor.new(user) }
+  
   it "creates a valid signup processor object" do
     expect(subject.class).to eq SignupProcessor
+  end
+  
+  it "should contain a user object on initialize" do
+    expect(subject.user.class).to eq User
+  end
+  
+  it "responds to proper methods" do
+    expect(subject.respond_to?(:find_invitations_by_email)).to be true
+  end
+  
+  it "finds invitations matching user's email" do
+    inviter = FactoryGirl.create(:user)
+    invitation = FactoryGirl.create(:invitation, inviter_id: inviter.id, email: user.email)
+    expect(subject.find_inivitations_by_email).to include invitation
   end
   # checks the database for invitations matching a certain email
   # builds friend requests for invitation creator to user w/ user email

--- a/spec/models/signup_processor_spec.rb
+++ b/spec/models/signup_processor_spec.rb
@@ -20,8 +20,15 @@ context "Signup_Processor" do
   it "finds invitations matching user's email" do
     inviter = FactoryGirl.create(:user)
     invitation = FactoryGirl.create(:invitation, inviter_id: inviter.id, email: user.email)
-    expect(subject.find_inivitations_by_email).to include invitation
+    expect(subject.find_invitations_by_email).to include invitation
   end
-  # checks the database for invitations matching a certain email
-  # builds friend requests for invitation creator to user w/ user email
+  
+  it "builds proper friendship requests for each invitation" do
+    inviter = FactoryGirl.create(:user)
+    invitation = FactoryGirl.create(:invitation, inviter_id: inviter.id, email: user.email)
+    subject.create_friendship_requests
+    friendship_request = FriendshipRequest.first
+    expect(friendship_request.sender_id).to eq inviter.id
+    expect(friendship_request.receiver_id).to eq user.id
+  end
 end

--- a/spec/models/signup_processor_spec.rb
+++ b/spec/models/signup_processor_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+context "Signup_Processor" do
+  
+  subject { SignupProcessor.new(user) }
+  it "creates a valid signup processor object" do
+    expect(subject.class).to eq SignupProcessor
+  end
+  # checks the database for invitations matching a certain email
+  # builds friend requests for invitation creator to user w/ user email
+end


### PR DESCRIPTION
Fix some logic so that right friendrequests shown on the right views
Add signup processor that builds a friendrequest between invited users and users that invited them when invited user signs up
